### PR TITLE
I add ENV priority for starting block being indexed on base & sepolia…

### DIFF
--- a/lib/const.js
+++ b/lib/const.js
@@ -1,5 +1,12 @@
-export const BASE_SEPOLIA_FIRST_BLOCK = 1149749;
-export const BASE_FIRST_BLOCK = 1149749;
+import dotenv from "dotenv";
+
+dotenv.config();
+
+export const BASE_SEPOLIA_FIRST_BLOCK = BigInt(
+  process.env.BASE_SEPOLIA_FIRST_BLOCK || "0"
+);
+export const BASE_FIRST_BLOCK = BigInt(process.env.BASE_FIRST_BLOCK || "0");
+
 // ABI for the SetupNewToken event
 export const eventSignature =
   "0x1b944478023872bf91b25a13fdba3a686fdb1bf4dbb872f850240fad4b8cc068";


### PR DESCRIPTION
…. If startBlock not provided, indexer begins at earliest block 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for environment variables for critical constants, enhancing configurability across different environments.
- **Bug Fixes**
	- Updated constants to default to `0` if environment variables are not set, ensuring stability.
- **Refactor**
	- Changed constants to `BigInt` to accommodate larger numerical values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->